### PR TITLE
using CreateGraphics repeatedly in draw() creates memory leaks. On large image sets this can crash java

### DIFF
--- a/atoMove/atoMove.pde
+++ b/atoMove/atoMove.pde
@@ -33,18 +33,19 @@
 //  The following global variables control
 //  various sim parameters
 
-int   numDots    = 8192;   // # of dots in the sim
-float dotCharge  = 0.20;   // Charge per dot, keep (numDots * numDots) lower than say 2000.
+int   numDots    = 1024;   // # of dots in the sim
+float dotCharge  = 0.5;   // Charge per dot, keep (numDots * numDots) lower than say 2000.
+
 //  Simulation controls
 //
-float blankLevel = 1.0;    // Threshold to repel (0.0 - 1.0, default: 1.0) 
+float blankLevel = 0.95;    // Threshold to repel (0.0 - 1.0, default: 1.0)
 float timeStep   = 0.001;  // Sim timestep       (Default: 0.001)
 float dMax       = 0.005;   // Max dot displacment    (Default: 0.005)
-float sustain    = 0.95;   // Sustained Velocity between steps (Default: 0.95) 
+float sustain    = 0.95;   // Sustained Velocity between steps (Default: 0.95)
 
 //  GLSL Sim buffer dimension
 //
-static int bufXY    = 128;    // GLSL workbuf dimensions, i.e. numDots MAX. 128^2 = 16384, 64^2 = 4096
+static int bufXY    = 256;    // GLSL workbuf dimensions, i.e. numDots MAX. 128^2 = 16384, 64^2 = 4096
 static int simXY    = 512;    // Electrostatic field resolution (higher, more expensive)
 
 //  Random seed (random() used in 'initDots' only)
@@ -58,7 +59,7 @@ PImage    velBuf, posBuf, fieldBuf;
 String    accShaderFile = "shaderAcc.glsl";
 String    velShaderFile = "shaderVel.glsl";
 String    posShaderFile = "shaderPos.glsl";
- 
+
 //  active 'Acc' buffer index
 int activeAcc = 0;
 
@@ -70,7 +71,8 @@ float vMax = dMax / dt;
 
 
 //  For image sequence processing
-
+PGraphics hBmp;
+PImage target;
 /*
 
   The following code assumes you want to process an image sequence.  The simulation
@@ -96,27 +98,27 @@ int simsPerTransition    = 250;  // 250 sim steps for the first output frame
 int samplesPerTransition = 1;    // only 1 sample output for the first transition 
 
 //  Your input image sequence relative to the Processing sketch
-String inputImagePrefix  = "C:/BadAppleHalftone/Bad Apple";
+String inputImagePrefix  = "../../resource/bw_png/bw_";
 String inputImageExt     = ".png";
-int    inputStartFrame   = 0; //0
-int    inputEndFrame     = 6571; // 6571
+int    inputStartFrame   = 1;
+int    inputEndFrame     = 50;
 int    inputSteps        = 1;
 int    inputFrameNum;
 
 //  Output frame names
 String outputImagePrefix  = "../../outputs/atoMove/mj_";
 String outputImageExt     = ".png";
-int outFrameNum           = 0;
-float dotRadius           = 6.0;
-PGraphics hBmp;
-PImage target;
+int outFrameNum           = 1;
+float dotRadius           = 8.0;
+
+
 //
 //  ======= Core Processing code ========
 //
 
 void setup() {
 
-  size(1440, 1080, P2D);  // Change the first 2 numbers output image size
+  size(512, 512, P2D);  // Change the first 2 numbers output image size
   background(0);
   noStroke();
   randomSeed(rndSeed); 
@@ -133,7 +135,6 @@ void setup() {
 
 void draw() {
   
-    //PImage target = loadImage(inputImagePrefix + nf(inputFrameNum, 4) + inputImageExt);
     target = loadImage(inputImagePrefix + nf(inputFrameNum, 4) + inputImageExt);
     updateField(target);  // refresh 'field'
 
@@ -151,7 +152,7 @@ void draw() {
     }
 
     // **** Update both simsPerTransition & samplesPerTranstion for the rest ****
-    samplesPerTransition = 1;   // take 2 samples per transition (give you some slow-mo)
+    samplesPerTransition = 2;   // take 2 samples per transition (give you some slow-mo)
     simsPerTransition    = 40;  // 40 sim steps per transition
         
 }
@@ -217,10 +218,7 @@ void initSIM() {
   posShader.set("u_resolution", float(bufXY), float(bufXY));
   posShader.set("u_numDots", numDots);
   posShader.set("u_dMax", dMax);
-  
-  
-  
-  
+   
   //  Workhorse offscreen engine for shaders
   hidden  = createGraphics(bufXY, bufXY, P2D);
 
@@ -269,7 +267,7 @@ void drawDots(int np, float r, color c) {
 //
 void updateField(PImage bmp) {
 
-  //PGraphics hBmp = createGraphics(simXY, simXY, P2D);
+
   fieldBuf = createImage(simXY, simXY, ARGB);
   hBmp.beginDraw();
   hBmp.image(bmp, 0, 0, simXY, simXY);
@@ -304,36 +302,34 @@ void updateField(PImage bmp) {
 //  Update 'Acc' shader uniforms
 //
 void updateAccShaderUniforms() {  
-  //accShader.set("u_resolution", float(bufXY), float(bufXY));
+
   accShader.set("u_pos", posBuf);
   accShader.set("u_bmpQ", fieldBuf);
-  //accShader.set("u_simXY", simXY);
-  //accShader.set("u_dotCharge", dotCharge);
-  //accShader.set("u_numDots", numDots);
+
 }
 
 //  Update 'Vel' shader uniforms
 //
 void updateVelShaderUniforms() {  
-  //velShader.set("u_resolution", float(bufXY), float(bufXY));
+
   velShader.set("u_vel", velBuf);
   velShader.set("u_a0", accBuf[1-activeAcc]);  // Last Acc.
   velShader.set("u_a1", accBuf[activeAcc]);    // Latest Acc.
   velShader.set("u_vMax", vMax);
-  //velShader.set("u_sustain", sustain);    
+    
   velShader.set("u_dt_2", dt_2);
-  //velShader.set("u_numDots", numDots);
+
 }
 
 //  Update 'Pos' shader uniforms
 //
 void updatePosShaderUniforms() {  
-  //posShader.set("u_resolution", float(bufXY), float(bufXY));
+
   posShader.set("u_pos", posBuf);
   posShader.set("u_vel", velBuf);
   posShader.set("u_acc", accBuf[activeAcc]);
-  //posShader.set("u_dMax", dMax);
+
   posShader.set("u_dt", dt);    
   posShader.set("u_dtt", dtt);  
-  //posShader.set("u_numDots", numDots);
+
 }

--- a/atoMove/atoMove.pde
+++ b/atoMove/atoMove.pde
@@ -71,7 +71,7 @@ float vMax = dMax / dt;
 
 
 //  For image sequence processing
-
+PGraphics hBmp;
 /*
 
   The following code assumes you want to process an image sequence.  The simulation
@@ -127,7 +127,7 @@ void setup() {
   initDots(numDots);
   
   inputFrameNum = inputStartFrame;
-  
+  hBmp = createGraphics(simXY, simXY, P2D);
 }
 
 
@@ -252,8 +252,7 @@ void drawDots(int np, float r, color c) {
 //
 void updateField(PImage bmp) {
 
-  PGraphics hBmp = createGraphics(simXY, simXY, P2D);
-  fieldBuf = createImage(simXY, simXY, ARGB);
+  
   hBmp.beginDraw();
   hBmp.image(bmp, 0, 0, simXY, simXY);
   fieldBuf = hBmp.copy();

--- a/atoMove/shaderAcc.glsl
+++ b/atoMove/shaderAcc.glsl
@@ -231,10 +231,10 @@ void main() {
     
     vec2 dp = dotPos - pos;
 
-    //if (dp.x > 1.0) dp.x -= 2.0;
-    //else if (dp.x < -1.0) dp.x += 2.0;
-    //if (dp.y > 1.0) dp.y -= 2.0;
-    //else if (dp.y < -1.0) dp.y += 2.0;
+    if (dp.x > 1.0) dp.x -= 2.0;
+    else if (dp.x < -1.0) dp.x += 2.0;
+    if (dp.y > 1.0) dp.y -= 2.0;
+    else if (dp.y < -1.0) dp.y += 2.0;
 
     float d2 = dot(dp, dp) + 0.00003;
     float d  = sqrt(d2);

--- a/atoMove/shaderAcc.glsl
+++ b/atoMove/shaderAcc.glsl
@@ -231,10 +231,10 @@ void main() {
     
     vec2 dp = dotPos - pos;
 
-    if (dp.x > 1.0) dp.x -= 2.0;
-    else if (dp.x < -1.0) dp.x += 2.0;
-    if (dp.y > 1.0) dp.y -= 2.0;
-    else if (dp.y < -1.0) dp.y += 2.0;
+    //if (dp.x > 1.0) dp.x -= 2.0;
+    //else if (dp.x < -1.0) dp.x += 2.0;
+    //if (dp.y > 1.0) dp.y -= 2.0;
+    //else if (dp.y < -1.0) dp.y += 2.0;
 
     float d2 = dot(dp, dp) + 0.00003;
     float d  = sqrt(d2);

--- a/atoMove/shaderPos.glsl
+++ b/atoMove/shaderPos.glsl
@@ -190,10 +190,10 @@ void main() {
 
   //  Make periodic
   pos += dp;   
-  //if (pos.x < -1.0) pos.x += 2.0;
-  //else if (pos.x > 1.0) pos.x -= 2.0;
-  //if (pos.y < -1.0) pos.y += 2.0;
-  //else if (pos.y > 1.0) pos.y -= 2.0;
+  if (pos.x < -1.0) pos.x += 2.0;
+  else if (pos.x > 1.0) pos.x -= 2.0;
+  if (pos.y < -1.0) pos.y += 2.0;
+  else if (pos.y > 1.0) pos.y -= 2.0;
   
   gl_FragColor = encodeV2(pos);  // Result to be rec'd by 'posBuf'
 

--- a/atoMove/shaderPos.glsl
+++ b/atoMove/shaderPos.glsl
@@ -190,10 +190,10 @@ void main() {
 
   //  Make periodic
   pos += dp;   
-  if (pos.x < -1.0) pos.x += 2.0;
-  else if (pos.x > 1.0) pos.x -= 2.0;
-  if (pos.y < -1.0) pos.y += 2.0;
-  else if (pos.y > 1.0) pos.y -= 2.0;
+  //if (pos.x < -1.0) pos.x += 2.0;
+  //else if (pos.x > 1.0) pos.x -= 2.0;
+  //if (pos.y < -1.0) pos.y += 2.0;
+  //else if (pos.y > 1.0) pos.y -= 2.0;
   
   gl_FragColor = encodeV2(pos);  // Result to be rec'd by 'posBuf'
 


### PR DESCRIPTION
Processing a large set of images (~6000):
Java crashed after about 4000 images having consumed 22GB of memory!

Moving creategraphics out of draw() so that we only have the one buffer for this purpose:
All ~6000 images have successfuly completed. memory usage did not exceed 500MB

